### PR TITLE
Feature/6 github action 이용하여 pypi 자동배포 적용

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,31 +9,31 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
+    release:
+        types:
+            - created
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
-  deploy:
+    deploy:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Python
+              uses: actions/setup-python@v3
+              with:
+                  python-version: '3.6'
+            - name: Install dependencies
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install build
+            - name: Build package
+              run: python -m build
+            - name: Publish package
+              uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+              with:
+                  user: __token__
+                  password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="vos_mjjo", # Replace with your own username
-    version="0.0.8",
+    version="0.0.9",
     author="mjjo",
     author_email="mj.jo@valueofspace.com",
     description="vos-mjjo package",


### PR DESCRIPTION
### 개요🔎

resolve #6 

### 작업사항✍🏻

- 적용결과
    
    <img width="1316" alt="스크린샷 2023-05-18 오후 10 04 53" src="https://github.com/jomujin/vos-mjjo/assets/76583614/0ff5b210-1d05-4eb3-b9f7-011dc95c4626">

    <img width="1424" alt="스크린샷 2023-05-18 오후 10 05 06" src="https://github.com/jomujin/vos-mjjo/assets/76583614/6a14732e-05f4-4f15-839e-ae87d33baf0e">

    <img width="1124" alt="스크린샷 2023-05-18 오후 10 05 12" src="https://github.com/jomujin/vos-mjjo/assets/76583614/0f17ca1e-4aa8-4524-acff-324869d8a409">


### 주의사항❗️

- setup에 기재된 README.md와 실제 readme.md의 대소문자 차이로 with read 구분에서 지속해서 오류가 발생했음
- publish.yml release type으로 해두어서 release 처리시 pypi 진행됨

### 리뷰어🤔
@jomujin 
