### PR TITLE
Feature/10 zfill(8) 추가하여 strftime(%Y%m%d) 처리시 1000미만의 연도에서 앞자리 0이 생략되는 이슈를 처리하라

### DIFF
--- a/mjjo/cordate.py
+++ b/mjjo/cordate.py
@@ -289,7 +289,7 @@ def _check_correct_ymd(
                 y = _convert_type_year(y)
                 candidate_date = datetime(y, m, d)
                 if (y > 0) and (y < (this_year +1)) and candidate_date:
-                    candidate_date = candidate_date.strftime("%Y%m%d")
+                    candidate_date = candidate_date.strftime("%Y%m%d").zfill(8)
                     candidate_dates.add(candidate_date)
             except:
                 pass


### PR DESCRIPTION
### 개요🔎

resolve #10 

### 작업사항✍🏻

- zfill(8) 추가하여 strftime(%Y%m%d) 처리시 1000미만의 연도에서 앞자리 0이 생략되는 이슈를 처리

### 주의사항❗️

내용을 적어주세요.

### 리뷰어🤔
@jomujin 
